### PR TITLE
feat: fetch products

### DIFF
--- a/app/data/products.json
+++ b/app/data/products.json
@@ -1,0 +1,11 @@
+[
+  "-7Yx3n06JS1p4bCaYW_nW",
+  "39hY9-W3dAYkZs1wzVTEB",
+  "B2Tiw1XG7ObSfpVgC1IfI",
+  "Gsz5G1bsNRBF8L3aoI9zI",
+  "VLMWdKoCRSL74naLb6U5s",
+  "i_wOIXd7LAWWuf6bED-0o",
+  "iqTCfxxDBD3V5xmiPiNbv",
+  "l5AjJuUhIwpABlttMgTfK",
+  "yxyBGxpvqczoMvUkxXQMZ"
+]

--- a/app/marketplace/products/[product_id]/index.tsx
+++ b/app/marketplace/products/[product_id]/index.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Product, ProductData } from "@/types";
+import { getDoc } from "@junobuild/core-peer";
+
+export default function ProductItem({
+  params,
+}: {
+  params: { product_id: string };
+}) {const [product, setProduct] = useState<Product | undefined>(undefined);
+
+  // TODO: here I hardcoded the satellite ID to fetch the document regardless if the Juno library is loaded or not.
+  // Currently this useEffect is run at runtime before initSatellite is performed
+  // Therefore, without this workaround it throws "No satellite ID defined. Did you initialize Juno?"
+  // This can remains as it but, another way to solve it would be to run this effect only once initSatellite has been executed
+  useEffect(() => {
+    (async () => {
+      const doc = await getDoc<ProductData>({
+        collection: "products",
+        key: params.product_id,
+        satellite: {
+          satelliteId: "mdw7w-piaaa-aaaal-ajoma-cai",
+        },
+      });
+
+      setProduct(doc);
+    })();
+  }, [])
+
+  return <>
+    <p>{params.product_id}</p>
+
+    <p>{product !== undefined && product.data.product_name}</p>
+  </>
+}

--- a/app/marketplace/products/[product_id]/page.tsx
+++ b/app/marketplace/products/[product_id]/page.tsx
@@ -1,20 +1,18 @@
 // directory: app/…/[product_id]/page.tsx
 
 import Container from "@/components/container";
-import { ProductData } from "@/types";
-import { listDocs } from "@junobuild/core-peer";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import ProductItem from "@/app/marketplace/products/[product_id]/index";
+
+export const dynamicParams = true;
+export const dynamic = 'force-static';
 
 export async function generateStaticParams() {
-  const { items } = await listDocs<ProductData>({
-    collection: "products",
-    satellite: {
-      satelliteId: "mdw7w-piaaa-aaaal-ajoma-cai",
-    },
-  });
+  const data = join(process.cwd(), "app", "data", "products.json");
+  const products = JSON.parse(((await readFile(data)).toString()));
 
-  return items.map((product) => ({
-    product_id: product.data.product_id,
-  }));
+  return products.map((product_id: string) => ({product_id}))
 }
 
 export default function ProductPage({
@@ -24,7 +22,7 @@ export default function ProductPage({
 }) {
   return (
     <Container className="flex min-h-[85vh] flex-col items-center justify-center py-8">
-      {params.product_id}
+      <ProductItem params={params} />
     </Container>
   );
 }

--- a/scripts/build.products.mjs
+++ b/scripts/build.products.mjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+import { listDocs } from "@junobuild/core-peer";
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const buildProducts = async () => {
+  const { items } = await listDocs({
+    collection: "products",
+    satellite: {
+      satelliteId: "mdw7w-piaaa-aaaal-ajoma-cai",
+    },
+  });
+
+  const destination = join(process.cwd(), "app", "data", "products.json");
+
+  await writeFile(destination, JSON.stringify(items.map(({data: {product_id}}) => product_id), null, 2));
+}
+
+await buildProducts();


### PR DESCRIPTION
### Issues

1. The Internet Computer does not support server-side rendering without a "workaround." Therefore, Juno does not support SSR, and static export is required for Next.js.

2. Next.js requires a `generateStaticParams` per route when pre-rendered. A route cannot contain both `generateStaticParams` and `use client`. That's why the page should be split into two: the page and the client part extracted into a component.

3. Agent-js does not work in `generateStaticParams`. For some reason, using the `@dfinity/agent` library in this hook leads to errors at build time, such as `Invalid signature from`. It seems agent-js has trouble fetching the IC when used in a pre-rendered Next.js page hook.

4. As reported in this [issue](https://github.com/vercel/next.js/issues/61213), Next.js does not accept an empty array as the return of `generateStaticParams`, even with `export const dynamic = 'force-static';`.

5. Next.js displays an error when developing with `dynamicParams`, but the behavior is different for production or development. In development, it throws a "not found" error, which is essentially a warning that blocks UI development, while in production, it returns a 404.

### Summary

3. and 4. contradict each other. One cannot build Next.js without returning any data at build time, but one cannot build data at build time because agent-js throws errors. No data is not acceptable, and loading data is not acceptable as well.

### Solution

- Create a script that populates the list of products into a static JSON file.
- Read that file in `generateStaticParams` to return the list of supported product IDs.
- Load the product at runtime in a separate component.

⚠️ This means that everytime a product is added, most probably the dapp should be deployed again but, not sure. The production behavior might be different that the development behavior. To be tested.

### Not Resolved in This PR

There is still one improvement that can be developed and which is not resolved in this PR. This PR hardcodes the satellite ID in the `getDoc` call because it would be cleaner not to do so. However, the `useEffect` runs before the library is initialized, so without this workaround, it leads to a "Satellite ID not found" error. It would be useful to run the Juno code only when the satellite is initialized.

### Idea for Improvements

This PR still tries to resolve fetching the products at runtime, but if there is no data that really needs to be fetched on the client side, the provided JS script can maybe be extended to save all the data in the JSON file, and the dapp can just be pre-rendered with static data. It then requires building the dapp when data changes, but that way, no data needs to be pre-rendered at runtime. Just an idea...
